### PR TITLE
Fix C++ Compile-Time Warnings

### DIFF
--- a/src/NRandomGenerator.h
+++ b/src/NRandomGenerator.h
@@ -50,7 +50,7 @@ NRandomGenerator* NRandomGenerator::getInstance() {
 	if (_theInstance == NULL) {
 		try {
 			_theInstance = new NRandomGenerator();
-		} catch (bad_alloc) {
+		} catch (const std::bad_alloc&) {
 			throw NError("NRandomGenerator: Unable to create the NRandomGenerator instance.");
 		}
 	}
@@ -62,7 +62,7 @@ void NRandomGenerator::create(uint seed) {
 	if (_theInstance == NULL) {
 		try {
 			_theInstance = new NRandomGenerator(seed);
-		} catch (bad_alloc) {
+		} catch (const std::bad_alloc&) {
 			throw NError("NRandomGenerator: Unable to create the NRandomGenerator instance.");
 		}
 	}

--- a/src/NRandomizer.cpp
+++ b/src/NRandomizer.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) {
 			correctTrace(matrix);                     // compensate for the limited precision
 		} while (!verifyMatrix(matrix));
 		NOutputHandler::print(matrix);
-	} catch (NError err) {
+	} catch (const NError& err) {
 		err.print();
 		return err.errorCode();
 	} catch (...) {

--- a/src/NSeparator.cpp
+++ b/src/NSeparator.cpp
@@ -141,7 +141,7 @@ NResult NSeparator::separate(const MatrixXcd& src, const vector<uint>& particleS
 		if (result._reason == NREASON_NONE) {
 			result._reason = NREASON_S;
 		}
-	} catch (NError err) {
+	} catch (const NError& err) {
 		// If the failure is critical (e.g. memory allocation failure) we should escalate the error.
 		// Otherwise, just set the termination reason to fail which means numerical error.
 		if (err.criticalFailure())

--- a/src/NSeparator.h
+++ b/src/NSeparator.h
@@ -125,7 +125,7 @@ NSeparator* NSeparator::getInstance() {
 	if (_theInstance == NULL) {
 		try {
 			_theInstance = new NSeparator();
-		} catch (bad_alloc) {
+		} catch (const std::bad_alloc&) {
 			throw NError("NSeparator: Unable to create the NSeparator instance.");
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char* argv[]) {
 
 #endif  // __NRUNONSERVER__
 
-	} catch (NError err) {
+	} catch (const NError& err) {
 		err.print();
 		return err.errorCode();
 	} catch (...) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "NInputHandler.h"
 #include "NOutputHandler.h"
 #include "NSeparator.h"
@@ -143,7 +145,7 @@ NResult runOnServer(int argc, char* argv1[]) {
 
 	// boost accuracy?
 	bool accuracyBoost = false;
-	if (argc == 8 && argv1[7] == "1") {
+	if (argc == 8 && strcmp(argv1[7], "1") == 0) {
 		accuracyBoost = true;
 	}
 


### PR DESCRIPTION
### Summary

This PR addresses all compiler warnings that were being generated during the build, improving code quality and ensuring cleaner builds across platforms (macOS/Linux).

### Changes

#### 1. Fix exception catching by value (`-Wcatch-value`)

**Problem:** Catching exceptions by value causes object slicing and unnecessary copying. Polymorphic types like `std::bad_alloc` lose their derived class information when caught by value.

**Solution:** Changed all exception catches to use `const` references.

| File | Before | After |
|------|--------|-------|
| `src/main.cpp` | `catch (NError err)` | `catch (const NError& err)` |
| `src/NSeparator.h` | `catch (bad_alloc)` | `catch (const std::bad_alloc&)` |
| `src/NSeparator.cpp` | `catch (NError err)` | `catch (const NError& err)` |
| `src/NRandomizer.cpp` | `catch (NError err)` | `catch (const NError& err)` |
| `src/NRandomGenerator.h` | `catch (bad_alloc)` (×2) | `catch (const std::bad_alloc&)` |

#### 2. Replace deprecated POSIX semaphores (`-Wdeprecated-declarations`)

**Problem:** `sem_init()` and related unnamed semaphore functions are deprecated on macOS (never fully implemented on Darwin).

**Solution:** Replaced semaphore-based thread synchronization in `NThreadPool_l.cpp` with portable pthread condition variables and mutex.

- Removed `#include <semaphore.h>`
- Replaced `sem_t* _threadsReady` with `int* _threadReady` flag array
- Added `pthread_mutex_t _readyLock` and `pthread_cond_t _readyCond`
- Updated `initThreadPool()`, `notifyThreadCreated()`, `waitForThreads()`, and `notifyWorkFinished()` to use condition variable pattern

#### 3. Fix string literal comparison (`-Wstring-compare`)

**Problem:** Comparing C-strings with `==` compares pointer addresses, not string contents. The result is unspecified when comparing against string literals.

**Solution:** Use `strcmp()` for proper string content comparison.

```cpp
// Before
if (argc == 8 && argv1[7] == "1")

// After  
if (argc == 8 && strcmp(argv1[7], "1") == 0)
```

Added `#include <cstring>` to `src/main.cpp`.

### Files Changed

- `src/main.cpp`
- `src/NSeparator.h`
- `src/NSeparator.cpp`
- `src/NRandomizer.cpp`
- `src/NRandomGenerator.h`
- `src/NThreadPool_l.cpp`
